### PR TITLE
reorganise gsoc22

### DIFF
--- a/internships/gsoc2022.md
+++ b/internships/gsoc2022.md
@@ -1,80 +1,115 @@
 # Welcome to sktime's Google Summer of Code program 2022! 
 
-sktime is participating in Google Summer of Code (GSoC) 2022. Join the sktime team for a summer full of coding, learning and fun. Be part of our diverse community and join our efforts to advance machine learning and time series analysis capabilities!
+Join the sktime team for a summer full of coding, learning and fun. Be part of our diverse community and join our efforts to advance machine learning and time series analysis capabilities, by helping create one of the first comprehensive time series ML toolboxes!
 
-We explicitly would like to encourage applications by groups underrepresented in the tech sector.
+We explicitly encourage applications by groups underrepresented in the tech sector.
 
-If you have questions, please feel free to reach out to us on [Slack](https://join.slack.com/t/sktime-group/shared_invite/zt-62i7aejn-vXc3nOWF26S_P3VXFPWisQ) or [GitHub discussions](https://github.com/alan-turing-institute/sktime/discussions). 
+If you have questions, please feel free to reach out to us on [Slack](https://join.slack.com/t/sktime-group/shared_invite/zt-62i7aejn-vXc3nOWF26S_P3VXFPWisQ) or [GitHub discussions](https://github.com/alan-turing-institute/sktime/discussions).
 
 The 2022 sktime GSoC program is subject to the [sktime Code of Conduct](https://www.sktime.org/en/stable/get_involved/code_of_conduct.html).
 
+In the remainder of this page:
+- Why sktime
+- The application process
+- What we expect from you
+- What you can expect from us
+- Projects
+- Mentors
+
 ## Why sktime?
-Time series data is ubiquitous in many applications. Examples include sensor readings from industrial processes, spectroscopy wave length data from chemical samples, or bed-side monitor medical data from patients. Developing advanced time series analysis capabilities for researchers and practitioners is one of the major challenges of contemporary machine learning. 
+Time series data is ubiquitous in many applications. Examples include sensor readings from industrial processes, spectroscopy wave length data from chemical samples, or bed-side monitor medical data from patients. Developing advanced time series analysis capabilities for researchers and practitioners is one of the major challenges of contemporary machine learning.
 
-sktime is a new Python toolbox for machine learning with time series and, to the best of our knowledge, the first unified toolbox for time series. Our ambition is to provide for time series what scikit-learn provides for tabular data. This involves extending scikit-learn to the different time series learning tasks, such as time series classification, clustering, forecasting and anomaly detection. To find out more, check out our [paper](http://learningsys.org/neurips19/assets/papers/sktime_ml_systems_neurips2019.pdf) published at the [Workshop on Systems for ML at NeurIPS 2019](http://learningsys.org/neurips19/). 
+sktime is a new Python toolbox for machine learning with time series and, to the best of our knowledge, the first unified toolbox for time series. Our ambition is to provide for time series what scikit-learn provides for tabular data. This involves extending scikit-learn to the different time series learning tasks, such as time series classification, clustering, forecasting and anomaly detection. To find out more, check out our [paper](http://learningsys.org/neurips19/assets/papers/sktime_ml_systems_neurips2019.pdf) published at the [Workshop on Systems for ML at NeurIPS 2019](http://learningsys.org/neurips19/).
 
-## How to apply?
-1. Make a pull request (PR) to sktime, as an entrance task, to show you are able to contribute meaningfully. Your PR does not need to be merged at your time of application. Find out more about how to contribute in general: look at our [new contributor starter issue](https://github.com/alan-turing-institute/sktime/issues/1147) and [developer guide](https://www.sktime.org/en/latest/developer_guide.html). 
-Alternatively, if you are already experienced in using git and GitHub in a collaborative environment, you can skip this step. In this case, in your application form, please provide a link to publicly visible evidence for your experience in the application form in step 2 below.
-2. Fill in and submit the sktime application form at (https://forms.gle/MVcf9Q45Ui1ByMxM8). You should have completed your entrance task (point 1 above) before submitting the form, since you need to provide a link to it in the form. Note: this form is separate from your GSoC proposal below.
-3. Submit a proposal on the GSoC platform (https://summerofcode.withgoogle.com). You can base this on the list of proposed projects (see below), your entrance task, or your own independent idea - whichever you choose, we aim to evaluate fairly and primarily on quality. If you submit a draft proposal, we are happy to provide feedback before the final submission. For general advice on how to write the proposal, have a look at the official guide: https://google.github.io/gsocguides/student/writing-a-proposal.
+## The application process
 
-The application deadline for completing all three steps above is April 19, 18:00 (UTC). 
+There are two main phases: the sktime application and GSoC proposal, and an interview. Details of these are below. The timeline is:
 
-If you get stuck or have questions, please feel free to reach out to us on [Slack](https://join.slack.com/t/sktime-group/shared_invite/zt-62i7aejn-vXc3nOWF26S_P3VXFPWisQ) or [GitHub discussions](https://github.com/alan-turing-institute/sktime/discussions). 
+- April 19, 18:00 (UTC). You must complete sktime application form and GSoC proposal by this deadline.
+- April 26. We will inform you of the outcome of the first phase *latest* by April 26, but hopefully sooner.
+- April 25 to May 8. Interviews will happen during this time. Preferred dates are April 29 and May 6. Please keep these dates free if possible.
+- May 15. We will take at most one week to inform you of the outcome of the interview. We submit our list of ranked candidates to GSoC committee.
+- May 20. GSoC will inform you of final outcome of the process.
 
-## What we expect
-GSoC is a marathon, not a sprint, and we expect good performance over the whole project. This means that you are in daily contact with your mentors and wider community and that you work full time on the project. 
+If you get stuck or have questions, please feel free to reach out to us on [Slack](https://join.slack.com/t/sktime-group/shared_invite/zt-62i7aejn-vXc3nOWF26S_P3VXFPWisQ) or [GitHub discussions](https://github.com/alan-turing-institute/sktime/discussions).
 
-In addition to the individual project work, all GSoC participants will be required (and have the opportunity) to:
+### sktime application and GSoC proposal
 
- * peer-review a fellow student's work in the middle and at the end of GSoC,
- * write weekly blog posts about your contribution and a final summary post at the end of the project,
- * have a good time web-socializing with the other members of the community.
+There are three steps for this. The deadline to complete all of them is April 19, 18:00 (UTC).
 
-## What you can expect to get out of your participation
+1. Make a pull request (PR) to sktime, as an entrance task, to show you are able to contribute meaningfully.
+    - Your PR does not need to be merged at your time of application.
+    - Find out more about how to contribute in general: look at our [new contributor starter issue](https://github.com/alan-turing-institute/sktime/issues/1147) and [developer guide](https://www.sktime.org/en/latest/developer_guide.html). 
+    - Alternatively, if you are already experienced in using git and GitHub in a collaborative environment, you can skip this step. In this case, in the form in step 2 below, please provide a link to publicly visible evidence for your experience.
+2. Fill in and submit the sktime application form at (https://forms.gle/MVcf9Q45Ui1ByMxM8).
+    - You should have completed your entrance task (point 1 above) before submitting the form, since you need to provide a link to it in the form.
+    - Note: this form is separate from your GSoC proposal below.
+3. Submit a proposal on the GSoC platform (https://summerofcode.withgoogle.com).
+    - You can base this on the list of proposed projects (see below), your entrance task, or your own independent idea - whichever you choose, we aim to evaluate fairly and primarily on quality.
+    - We are happy to provide feedback on a draft proposal before the final submission.
+    - For general advice on how to write the proposal, look at the official guide: https://google.github.io/gsocguides/student/writing-a-proposal.
 
-The stipend will allow you to aquire cutting edge skills and participate in intensive mentoring sessions, in highly sought-after areas of data science (time series, toolboxes, healthcare & industry applications). 
+After the deadline on April 19th has passed, we will process the information provided and tell you the outcome of this phase no later than April 26th. There are two possible outcomes:
+- Progress to interview. See below.
+- Rejection. Though this will be disheartening for you, this is only a rejection for GSoC (which is particularly demanding of participants) and should not discourage you from pursuing open source contributions, either with sktime or another package. E.g. you may still be eligible for our (unpaid) 1-1 mentoring.
 
-Ultimately, one of our key goals is to onboard new *long-term* developers who are willing to step up and become next generation leaders in open source toolbox development.
+### Interview
+If successful in the first phase, we will invite you to a structured interview (ca. 30 to 60 minutes length; to be finalised) with core community members of sktime.
+The interview will happen in the two-week period April 26 to May 8, and our preferred dates are April 29 and May 6. Please keep these dates free if possible.
 
-## Candidate selection process
-A pre-selection will be carried out for applications submitted by April 19, 18:00 (UTC), based on the submitted application form and linked material. You will receive notification of the pre-selection outcome no later than April 26.
+During the interview:
+- we will ask you to give a short (5 to 10 minutes; to be finalised) presentation on a piece of Python code that you wrote
+- we will ask about your motivation to join sktime, your previous experience, your suitability for the specified project, and you general technical background in data science and Python.
 
-The outcome of the pre-selection can be either progression to the next stage, or a rejection. In the latter case, we would still very much welcome collaboration and contribution outside GSoC. For example, you may be eligible for (unpaid) mentoring.
+After the interview, we will rank the candidates and send a list of our preferred candidates to GSoC, who will make the final decisions and allocations.
+We will inform you of *our* perspective on the interviews (see below for possible outcomes) at most one week after the final candidate is interviewed, and GSoC will inform you of the final decision by May 20.
 
-If successful in the pre-selection, we will invite you to a structured interview (ca. 60 minutes length) with core community members of sktime, in the weeks of April 25 and May 2.
-Preferred dates are April 29 and May 6. Please keep these dates free if possible.
+When we inform you of the outcome of the interview, there are three possibilities:
+* Conditional fast-track acceptance. This means we put you as one of the top three ranking candidates, in our list sent to GSoC. This means highly likely - but not guaranteed - acceptance to the sktime GSoC program.
+* Conditional acceptance. This means you are in our list sent to GSoC.  This means likely - but not guaranteed - acceptance to the sktime GSoC program.
+* A rejection. This means you are not in our list sent to GSoC for 2022.
+  - We understand this will be disheartening for you, but this is only a rejection for GSoC, which is particularly demanding of participants. We will always welcome anybody interested in joining sktime outside of GSoC.
 
-During the interview, you will be expected to give a 10-minute presentation on a piece of Python code that you wrote. The interview will also focus on your motivation to join sktime, prior work experience, suitability for the specified project, and general technical background in data science and Python software development. 
+## What we expect from you
+GSoC is a marathon, not a sprint, and we expect good performance over the whole project.
 
-The interview can have the following three outcomes:
-* Conditional fast-track acceptance to the sktime GSoC 2022. This means you are one of the three top ranking candidates. This means highly likely - but not guaranteed - acceptance to the GSoC program, but can still result in a rejection (see below).
-* Conditional acceptance to the sktime GSoC 2022. This means you are on the ranked list put forward to sktime.  This means likely - but not guaranteed - acceptance to the GSoC program, but can still result in a rejection (see below).
-* A rejection for GSoC 2022. This means you are not put forward to any of the GSoC 2022 slots by the sktime team - but we would still very much welcome collaboration and contribution, outside of GSoC 2022, if you are interested.
+Our expectations for GSoC participants before GSoC starts:
+ * You are interested in time series, machine learning, statistics, API design and software architecture.
+ * You like coding in Python.
+ * You are familiar with the basic data science ecosystem in Python, including numpy, pandas and scikit-learn.
+ * You enjoy working with a vibrant team of experienced ML scientists and software engineers.
+ * You are enthusiastic about open-source.
 
-The interview outcome will be communicated to you no later than one week after the interview itself. You will receive full confirmation of acceptance or rejection (from sktime and GSoC) on May 20, directly by GSoC.
+Our expectations for GSoC participants during GSoC:
+* You follow our [Code of Conduct](https://www.sktime.org/en/stable/get_involved/code_of_conduct.html).
+* You work full time on your GSoC project.
+* You maintain daily contact with your mentor(s).
+* You engage with the sktime community and other GSoC participants.
+* You peer-review a fellow student's work in the middle and at the end of GSoC.
+* You write weekly blog posts and a final summary post at the end of the project.
+* You consider becoming a *long-term* developer and contributor, stepping up to become a leader in open source toolbox development.
 
-## What we are looking for
-We're actively looking for contributors and your help is extremely welcome. Therefore, if
- * you are interested in time series, machine learning (ML), statistics, API design and software architecture,
- * you like coding in Python,
- * you are familiar with the basic data science ecosystem in Python, including numpy, pandas and scikit-learn, 
- * you enjoy working with a vibrant team of experienced ML scientists and software engineers,
- * you always wanted to join an open-source community,
+## What you can expect from us
+The expectations on you are high, but you can expect just as much from us. You should expect:
+* We follow the [Code of Conduct](https://www.sktime.org/en/stable/get_involved/code_of_conduct.html).
+* 1-1 mentoring with an experienced contributor.
+* Regular feedback on your efforts, including blogposts.
+* Cutting edge projects in high sought-after areas of data science: time series, toolboxes, applications to healthcare and industry.
+* The opportunity to acquire a variety of transferrable skills, both technical skills (like coding, design, testing, documentation) and soft skills (teamwork, giving and receiving feedback, goal setting).
+* The opportunity to engage and socialise with the sktime community and other GSoC participants.
+* The opportunity to become a core developer of sktime.
 
-then GSoC with sktime is for you! You'll spend the summer working with our enthusiastic and open-minded team of developers who are creating one of the first comprehensive time series ML toolboxes out there.
 
 ## Projects
 For potential projects, see our [list of suggested projects](https://github.com/sktime/mentoring/blob/main/internships/projects_2022.md) and [good first issues](https://github.com/alan-turing-institute/sktime/labels/good%20first%20issue).
 We also appreciate applications with your own ideas!
 
-## Mentors 2022
+## Mentors
 
 | Name  | GitHub | Website |
 |---|---|---|
 | Franz Király | [@fkiraly](https://github.com/fkiraly) | [website](https://uk.linkedin.com/in/franz-kir%C3%A1ly-10a1391ba) |
 | Guzal Bulatova | [@guzalbulatova](https://github.com/guzalbulatova) | | 
-| Lovkush Agarwal | [@lovkush-a](https://github.com/lovkush-a) | | 
+| Lovkush Agarwal | [@lovkush-a](https://github.com/lovkush-a) | [personal website](www.lovkush.com)|
 | Lukasz Mentel | [@lmmentel](https://github.com/lmmentel) | [website](https://no.linkedin.com/in/lukasz-mentel) | 
 | Martin Walter | [@aiwalter](https://github.com/aiwalter) | | 

--- a/internships/gsoc2022.md
+++ b/internships/gsoc2022.md
@@ -23,21 +23,21 @@ sktime is a new Python toolbox for machine learning with time series and, to the
 
 ## The application process
 
-There are two main phases: the sktime application and GSoC proposal, and an interview. Details of these are below. The timeline is:
+Here is the timeline for the application process. Each of the steps is explained in detail below.
 
-- April 19, 18:00 (UTC). You must complete sktime application form and GSoC proposal by this deadline.
-- April 26. We will inform you of the outcome of the first phase *latest* by April 26, but hopefully sooner.
+- April 19, 18:00 (UTC). You must complete an entrance task, the sktime application form and GSoC proposal by this deadline.
+- April 26. We will inform you of the outcome of your application *latest* by April 26, but hopefully sooner.
 - April 25 to May 8. Interviews will happen during this time. Preferred dates are April 29 and May 6. Please keep these dates free if possible.
 - May 15. We will take at most one week to inform you of the outcome of the interview. We submit our list of ranked candidates to GSoC committee.
 - May 20. GSoC will inform you of final outcome of the process.
 
 If you get stuck or have questions, please feel free to reach out to us on [Slack](https://join.slack.com/t/sktime-group/shared_invite/zt-62i7aejn-vXc3nOWF26S_P3VXFPWisQ) or [GitHub discussions](https://github.com/alan-turing-institute/sktime/discussions).
 
-### sktime application and GSoC proposal
+### Entrace task, sktime application and GSoC proposal
 
-There are three steps for this. The deadline to complete all of them is April 19, 18:00 (UTC).
+The deadline to complete all of these is April 19, 18:00 (UTC).
 
-1. Make a pull request (PR) to sktime, as an entrance task, to show you are able to contribute meaningfully.
+1. Entrance task. Make a pull request (PR) to sktime to show you are able to contribute meaningfully.
     - Your PR does not need to be merged at your time of application.
     - Find out more about how to contribute in general: look at our [new contributor starter issue](https://github.com/alan-turing-institute/sktime/issues/1147) and [developer guide](https://www.sktime.org/en/latest/developer_guide.html). 
     - Alternatively, if you are already experienced in using git and GitHub in a collaborative environment, you can skip this step. In this case, in the form in step 2 below, please provide a link to publicly visible evidence for your experience.
@@ -49,12 +49,12 @@ There are three steps for this. The deadline to complete all of them is April 19
     - We are happy to provide feedback on a draft proposal before the final submission.
     - For general advice on how to write the proposal, look at the official guide: https://google.github.io/gsocguides/student/writing-a-proposal.
 
-After the deadline on April 19th has passed, we will process the information provided and tell you the outcome of this phase no later than April 26th. There are two possible outcomes:
+After the deadline on April 19th has passed, we will process the information provided and tell you the outcome no later than April 26th. There are two possible outcomes:
 - Progress to interview. See below.
 - Rejection. Though this will be disheartening for you, this is only a rejection for GSoC (which is particularly demanding of participants) and should not discourage you from pursuing open source contributions, either with sktime or another package. E.g. you may still be eligible for our (unpaid) 1-1 mentoring.
 
 ### Interview
-If successful in the first phase, we will invite you to a structured interview (ca. 30 to 60 minutes length; to be finalised) with core community members of sktime.
+If successful in the above steps, we will invite you to a structured interview (ca. 30 to 60 minutes length; to be finalised) with core community members of sktime.
 The interview will happen in the two-week period April 26 to May 8, and our preferred dates are April 29 and May 6. Please keep these dates free if possible.
 
 During the interview:

--- a/internships/gsoc2022.md
+++ b/internships/gsoc2022.md
@@ -38,7 +38,7 @@ If you get stuck or have questions, please feel free to reach out to us on [Slac
 The deadline to complete all of these is April 19, 18:00 (UTC).
 
 1. Entrance task. Make a pull request (PR) to sktime to show you are able to contribute meaningfully.
-    - Your PR does not need to be merged at your time of application.
+    - Your PR does not need to be merged at the time of application.
     - To find out how to contribute to sktime, look at our [new contributor starter issue](https://github.com/alan-turing-institute/sktime/issues/1147) and [developer guide](https://www.sktime.org/en/latest/developer_guide.html). 
     - Alternatively, if you are already experienced in using git and GitHub in a collaborative environment, you can skip this step. In this case, in the form in step 2 below, please provide a link to publicly visible evidence for your experience.
 2. Fill in and submit the sktime application form at (https://forms.gle/MVcf9Q45Ui1ByMxM8).
@@ -58,8 +58,8 @@ If successful in the above steps, we will invite you to a structured interview (
 The interview will happen in the two-week period April 26 to May 8, and our preferred dates are April 29 and May 6. Please keep these dates free if possible.
 
 During the interview:
-- we will ask you to give a short (5 to 10 minutes; to be finalised) presentation on a piece of Python code that you wrote
-- we will ask about your motivation to join sktime, your previous experience, your suitability for the specified project, and your general technical background in data science and Python.
+- we will ask you to give a short (5 to 10 minutes; to be finalised) presentation on a piece of Python code that you wrote. Please be ready to screen share your code or to send a link to the repo containing your code.
+- we will ask about your motivation to join sktime, your previous experience, your suitability for the specified project, and technical questions on data science and Python.
 
 After the interview, we will rank the candidates and send a list of our preferred candidates to GSoC, who will make the final decisions and allocations. 
 We will inform you of *our* perspective on the interviews (see below for possible outcomes) at most one week after the final candidate is interviewed, and GSoC will inform you of the final decision by May 20.
@@ -92,8 +92,9 @@ Our expectations for GSoC participants during GSoC:
 ## What you can expect from us
 The expectations on you are high, but you can expect just as much from us. You should expect:
 * We follow the [Code of Conduct](https://www.sktime.org/en/stable/get_involved/code_of_conduct.html).
-* 1-1 mentoring with an experienced contributor.
-* Regular feedback on your efforts, including blogposts.
+* 1-1 mentoring with an experienced contributor, with weekly meetings.
+* Regular feedback and help on your efforts, including blogposts, with quick responses from us (usually respond within 2 working days).
+* 'Agile' ways of working, used throughout the tech industry, e.g. daily standups.
 * Cutting edge projects in highly sought-after areas of data science: time series, toolboxes, applications to healthcare and industry.
 * The opportunity to acquire a variety of transferrable skills, both technical skills (like coding, design, testing, documentation) and soft skills (teamwork, giving and receiving feedback, goal setting).
 * The opportunity to engage and socialise with the sktime community and other GSoC participants.
@@ -104,7 +105,7 @@ The expectations on you are high, but you can expect just as much from us. You s
 For potential projects, see our [list of suggested projects](https://github.com/sktime/mentoring/blob/main/internships/projects_2022.md) and [good first issues](https://github.com/alan-turing-institute/sktime/labels/good%20first%20issue).
 We also appreciate applications with your own ideas!
 
-## Mentors
+## Mentors 2022
 
 | Name  | GitHub | Website |
 |---|---|---|

--- a/internships/gsoc2022.md
+++ b/internships/gsoc2022.md
@@ -39,7 +39,7 @@ The deadline to complete all of these is April 19, 18:00 (UTC).
 
 1. Entrance task. Make a pull request (PR) to sktime to show you are able to contribute meaningfully.
     - Your PR does not need to be merged at your time of application.
-    - Find out more about how to contribute in general: look at our [new contributor starter issue](https://github.com/alan-turing-institute/sktime/issues/1147) and [developer guide](https://www.sktime.org/en/latest/developer_guide.html). 
+    - To find out how to contribute to sktime, look at our [new contributor starter issue](https://github.com/alan-turing-institute/sktime/issues/1147) and [developer guide](https://www.sktime.org/en/latest/developer_guide.html). 
     - Alternatively, if you are already experienced in using git and GitHub in a collaborative environment, you can skip this step. In this case, in the form in step 2 below, please provide a link to publicly visible evidence for your experience.
 2. Fill in and submit the sktime application form at (https://forms.gle/MVcf9Q45Ui1ByMxM8).
     - You should have completed your entrance task (point 1 above) before submitting the form, since you need to provide a link to it in the form.
@@ -59,9 +59,9 @@ The interview will happen in the two-week period April 26 to May 8, and our pref
 
 During the interview:
 - we will ask you to give a short (5 to 10 minutes; to be finalised) presentation on a piece of Python code that you wrote
-- we will ask about your motivation to join sktime, your previous experience, your suitability for the specified project, and you general technical background in data science and Python.
+- we will ask about your motivation to join sktime, your previous experience, your suitability for the specified project, and your general technical background in data science and Python.
 
-After the interview, we will rank the candidates and send a list of our preferred candidates to GSoC, who will make the final decisions and allocations.
+After the interview, we will rank the candidates and send a list of our preferred candidates to GSoC, who will make the final decisions and allocations. 
 We will inform you of *our* perspective on the interviews (see below for possible outcomes) at most one week after the final candidate is interviewed, and GSoC will inform you of the final decision by May 20.
 
 When we inform you of the outcome of the interview, there are three possibilities:
@@ -94,7 +94,7 @@ The expectations on you are high, but you can expect just as much from us. You s
 * We follow the [Code of Conduct](https://www.sktime.org/en/stable/get_involved/code_of_conduct.html).
 * 1-1 mentoring with an experienced contributor.
 * Regular feedback on your efforts, including blogposts.
-* Cutting edge projects in high sought-after areas of data science: time series, toolboxes, applications to healthcare and industry.
+* Cutting edge projects in highly sought-after areas of data science: time series, toolboxes, applications to healthcare and industry.
 * The opportunity to acquire a variety of transferrable skills, both technical skills (like coding, design, testing, documentation) and soft skills (teamwork, giving and receiving feedback, goal setting).
 * The opportunity to engage and socialise with the sktime community and other GSoC participants.
 * The opportunity to become a core developer of sktime.


### PR DESCRIPTION
the changes include:

- adding a list of contents at the top
- combining 'how to apply' and 'selection process' into one section
- combining 'what we expect from you' and 'what we are looking for' into one section
- adding a timeline to the application process
- convert some paragraphs into bullet lists
- various minor tweaks to the wording