### PR TITLE
add process for getting feedback on draft proposal

### DIFF
--- a/internships/gsoc2022.md
+++ b/internships/gsoc2022.md
@@ -51,7 +51,6 @@ The deadline to complete all of these is April 19, 18:00 (UTC). If you want feed
     - Alternatively, if you are already experienced in using git and GitHub in a collaborative environment, you can skip this step. In this case, in the form in step 2 below, please provide a link to publicly visible evidence for your experience.
 2. Fill in and submit the sktime application form at (https://forms.gle/MVcf9Q45Ui1ByMxM8).
     - You should have completed your entrance task (point 1 above) before submitting the form, since you need to provide a link to it in the form.
-    - If you want to receive feedback on a draft proposal, please select the
     - Note: this form is separate from your GSoC proposal below.
 3. Submit a proposal on the GSoC platform (https://summerofcode.withgoogle.com).
     - You can base this on the list of proposed projects (see below), your entrance task, or your own independent idea - whichever you choose, we aim to evaluate fairly and primarily on quality.

--- a/internships/gsoc2022.md
+++ b/internships/gsoc2022.md
@@ -11,21 +11,29 @@ The 2022 sktime GSoC program is subject to the [sktime Code of Conduct](https://
 In the remainder of this page:
 - Why sktime
 - The application process
+  - Entrace task, sktime application and GSoC proposal
+  - Getting feedback on draft proposal
+  - Interview
 - What we expect from you
 - What you can expect from us
 - Projects
 - Mentors
+
+
 
 ## Why sktime?
 Time series data is ubiquitous in many applications. Examples include sensor readings from industrial processes, spectroscopy wave length data from chemical samples, or bed-side monitor medical data from patients. Developing advanced time series analysis capabilities for researchers and practitioners is one of the major challenges of contemporary machine learning.
 
 sktime is a new Python toolbox for machine learning with time series and, to the best of our knowledge, the first unified toolbox for time series. Our ambition is to provide for time series what scikit-learn provides for tabular data. This involves extending scikit-learn to the different time series learning tasks, such as time series classification, clustering, forecasting and anomaly detection. To find out more, check out our [paper](http://learningsys.org/neurips19/assets/papers/sktime_ml_systems_neurips2019.pdf) published at the [Workshop on Systems for ML at NeurIPS 2019](http://learningsys.org/neurips19/).
 
+
+
 ## The application process
 
 Here is the timeline for the application process. Each of the steps is explained in detail below.
 
 - April 19, 18:00 (UTC). You must complete an entrance task, the sktime application form and GSoC proposal by this deadline.
+  - If you want feedback on a *draft* proposal, then you must complete the entrance task, the sktime application form and a *draft* GSoC proposal one week earlier. See details below.
 - April 26. We will inform you of the outcome of your application *latest* by April 26, but hopefully sooner.
 - April 25 to May 8. Interviews will happen during this time. Preferred dates are April 29 and May 6. Please keep these dates free if possible.
 - May 15. We will take at most one week to inform you of the outcome of the interview. We submit our list of ranked candidates to GSoC committee.
@@ -35,7 +43,7 @@ If you get stuck or have questions, please feel free to reach out to us on [Slac
 
 ### Entrace task, sktime application and GSoC proposal
 
-The deadline to complete all of these is April 19, 18:00 (UTC).
+The deadline to complete all of these is April 19, 18:00 (UTC). If you want feedback on a *draft* proposal, then you must complete the entrance task, the sktime application form and a *draft* GSoC proposal one week earlier. See next subsection for details.
 
 1. Entrance task. Make a pull request (PR) to sktime to show you are able to contribute meaningfully.
     - Your PR does not need to be merged at the time of application.
@@ -43,15 +51,25 @@ The deadline to complete all of these is April 19, 18:00 (UTC).
     - Alternatively, if you are already experienced in using git and GitHub in a collaborative environment, you can skip this step. In this case, in the form in step 2 below, please provide a link to publicly visible evidence for your experience.
 2. Fill in and submit the sktime application form at (https://forms.gle/MVcf9Q45Ui1ByMxM8).
     - You should have completed your entrance task (point 1 above) before submitting the form, since you need to provide a link to it in the form.
+    - If you want to receive feedback on a draft proposal, please select the
     - Note: this form is separate from your GSoC proposal below.
 3. Submit a proposal on the GSoC platform (https://summerofcode.withgoogle.com).
     - You can base this on the list of proposed projects (see below), your entrance task, or your own independent idea - whichever you choose, we aim to evaluate fairly and primarily on quality.
-    - We are happy to provide feedback on a draft proposal before the final submission.
     - For general advice on how to write the proposal, look at the official guide: https://google.github.io/gsocguides/student/writing-a-proposal.
 
 After the deadline on April 19th has passed, we will process the information provided and tell you the outcome no later than April 26th. There are two possible outcomes:
 - Progress to interview. See below.
 - Rejection. Though this will be disheartening for you, this is only a rejection for GSoC (which is particularly demanding of participants) and should not discourage you from pursuing open source contributions, either with sktime or another package. E.g. you may still be eligible for our (unpaid) 1-1 mentoring.
+
+### Getting feedback on draft proposal
+If you want feedback on a draft proposal, then you must complete the entrance task, the sktime application form and a draft GSoC proposal by April 12, 18:00 (UTC).
+
+1. Entrance task. Same as above.
+2. Fill in and submit the sktime application form. Same as above except:
+    - Select 'Yes' for the question 'Are you requesting feedback on your application/proposal?'
+3. Upload your draft proposal on the GSoC platform (https://summerofcode.withgoogle.com).
+
+After the deadline on April 12th has passed, we will try to provide feedback to you within three working days. Unfortunately, due to having limited time, we cannot *guarantee* that all people who want feedback will receive feedback, but we will do our best. If we cannot provide feedback to all people, then we will give preference to people who completed the steps earlier.
 
 ### Interview
 If successful in the above steps, we will invite you to a structured interview (ca. 30 to 60 minutes length; to be finalised) with core community members of sktime.
@@ -68,6 +86,8 @@ When we inform you of the outcome of the interview, there are two possibilities:
 * Conditional acceptance. This means you are in our shortlist sent to GSoC.  This means likely - but not guaranteed - acceptance to the sktime GSoC program.
 * A rejection. This means you are not in our shortlist sent to GSoC for 2022.
   - We understand this will be disheartening for you, but this is only a rejection for GSoC, which is particularly demanding of participants. We will always welcome anybody interested in joining sktime outside of GSoC.
+
+
 
 ## What we expect from you
 GSoC is a marathon, not a sprint, and we expect good performance over the whole project.
@@ -88,6 +108,8 @@ Our expectations for GSoC participants during GSoC:
 * You write weekly blog posts and a final summary post at the end of the project.
 * You consider becoming a *long-term* developer and contributor, stepping up to become a leader in open source toolbox development.
 
+
+
 ## What you can expect from us
 The expectations on you are high, but you can expect just as much from us. You should expect:
 * We follow the [Code of Conduct](https://www.sktime.org/en/stable/get_involved/code_of_conduct.html).
@@ -103,6 +125,8 @@ The expectations on you are high, but you can expect just as much from us. You s
 ## Projects
 For potential projects, see our [list of suggested projects](https://github.com/sktime/mentoring/blob/main/internships/projects_2022.md) and [good first issues](https://github.com/alan-turing-institute/sktime/labels/good%20first%20issue).
 We also appreciate applications with your own ideas!
+
+
 
 ## Mentors 2022
 


### PR DESCRIPTION
updated instructions to include this.

while writing these instructions, noticed that one downside is that we now have potential for confusion with having two deadlines. something to consider for future years.

once this is merged, i will write message in slack pointing to this page, explaining we have included instructions for early feedback.