### PR TITLE
[BUG] update get started with HackMD link

### DIFF
--- a/template.md
+++ b/template.md
@@ -25,7 +25,7 @@ The sktime mentorship programme is inspired by the [The Turing Way](https://the-
 ## Week 0
 
 - For reference: sktime's [mentorship programme call for applications](https://www.sktime.net/en/latest/get_involved/mentoring.html)
-- Get started with HackMD using this short guide: https://hackmd.io/@openlifesci/OLS-HackMD-guide
+- Get started with HackMD using this short guide: https://hackmd.io/@openlifescience/OLS-HackMD-guide
 - Please read our [Code of Conduct](https://www.sktime.net/en/latest/get_involved/code_of_conduct.html)
 - [guide for getting started as an sktime contributor](https://www.sktime.net/en/latest/get_involved/contributing.html#contributing)
 - [current list of project ideas](https://github.com/sktime/mentoring/blob/main/internships/projects_2023.md)


### PR DESCRIPTION
I noticed a small typo in the current link provided in the template for `getting started with HackMD`, which is leading to a `404 Not Found error`. I have corrected it in this PR. 

Also, I was considering updating the link to the roadmap as it appears to be directing readers to the outdated version. Unfortunately, I couldn't locate the latest roadmap. The one I found on [sktime website](https://www.sktime.net/en/latest/roadmap.html) seems to be old and hasn't been updated too. is there a latest version?

fyi @fkiraly @achieveordie 