### PR TITLE
Replace invalid 'The Turing Way' website link with it's correct website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,5 @@ Useful information for prospective students and supervisors:
 ## Resources
 * [`template.md`](https://github.com/sktime/mentorship-programme/blob/master/template.md) provides a template for keeping notes during the mentorship program on [HackMD](https://hackmd.io).
 * [Open Life Science](https://openlifesci.org)
-* [The Turing Way](https://the-turing-way.netlify.app/welcome)
+* [The Turing Way](https://book.the-turing-way.org/)
 * [9 Questions Before Starting a Mentoring Program](http://www.mentoringstandard.com/9-questions-before-starting-a-mentoring-program/)

--- a/template.md
+++ b/template.md
@@ -15,7 +15,7 @@ This is a collaborative document to keep track of progress during the mentorship
 
 
 ## References
-The sktime mentorship programme is inspired by the [The Turing Way](https://the-turing-way.netlify.app/welcome) project and [Open Life Science](https://openlifesci.org) programme under a CC BY 4.0, Open Life Science (OLS-2), 2020 license.
+The sktime mentorship programme is inspired by the [The Turing Way](https://book.the-turing-way.org/) project and [Open Life Science](https://openlifesci.org) programme under a CC BY 4.0, Open Life Science (OLS-2), 2020 license.
 
 
 **Contents**


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes third part ('The Turing Way' website's link) of issue [#8532](https://github.com/sktime/sktime/issues/8532) from sktime/sktime repository. 

#### What does this implement/fix? Explain your changes.
Replace the invalid 'The Turing Way' website [link](https://book.the-turing-way.org/welcome) with it's correct website [link](https://book.the-turing-way.org/). 

#### What should a reviewer concentrate their feedback on?
Check if current website link works from your end. If not, check whether the new link is the correct one to replace with. 